### PR TITLE
Feat dynamic charts Game Activity plugin

### DIFF
--- a/source/Constants.xaml
+++ b/source/Constants.xaml
@@ -10,6 +10,8 @@
     <HorizontalAlignment x:Key="DetailsViewBackgroundHorizontalAlignment">Left</HorizontalAlignment>
     <sys:Boolean x:Key="DetailsViewAllowUseOfLogos">true</sys:Boolean>
     <sys:Boolean x:Key="DetailsViewShowHltbDataGrid">true</sys:Boolean>
+    <sys:Double x:Key="GameActivityChartTimeHeight">100</sys:Double>
+    <sys:Double x:Key="GameActivityChartLogHeight">100</sys:Double>
     <sys:Boolean x:Key="GridViewAllowUseOfLogos">true</sys:Boolean>
     <sys:Boolean x:Key="GridViewShowHltbDataGrid">true</sys:Boolean>
     <sys:Boolean x:Key="GridViewEnableCoverShineAnimation">true</sys:Boolean>

--- a/source/Views/DetailsViewGameOverview.xaml
+++ b/source/Views/DetailsViewGameOverview.xaml
@@ -716,8 +716,8 @@
                                                         </Grid.RowDefinitions>
                                                         <Border Style="{DynamicResource OutlineBorder}" />
                                                         <StackPanel Orientation="Vertical" Background="{TemplateBinding Background}" Margin="10">
-                                                            <ContentControl x:Name="GameActivity_PluginChartTime" Margin="0,0,0,10" />
-                                                            <ContentControl x:Name="GameActivity_PluginChartLog"  Margin="0,0,0,10"/>
+                                                            <ContentControl x:Name="GameActivity_PluginChartTime" Margin="0,0,0,10" MinHeight="{DynamicResource GameActivityChartTimeHeight}" />
+                                                            <ContentControl x:Name="GameActivity_PluginChartLog"  Margin="0,0,0,10" MinHeight="{DynamicResource GameActivityChartLogHeight}"/>
                                                             <ContentControl x:Name="GameActivity_PluginButton" HorizontalAlignment="Right"/>
                                                         </StackPanel>
                                                     </Grid>

--- a/source/thememodifier.yaml
+++ b/source/thememodifier.yaml
@@ -7,6 +7,8 @@ Constants:
   - DetailsViewBackgroundHorizontalAlignment: "Horizontal alignment of the background image"
   - DetailsViewAllowUseOfLogos: "Allow use of Extra Metadata Loader logos"
   - DetailsViewShowHltbDataGrid: "Show HowLongToBeat data grid"
+  - GameActivityChartTimeHeight(100,500): "Height of Game Activity Plugin chart time"
+  - GameActivityChartLogHeight(100,500): "Height of Game Activity Plugin chart log"
   - "Grid View"
   - GridViewAllowUseOfLogos: "Allow use of Extra Metadata Loader logos"
   - GridViewShowHltbDataGrid: "Show HowLongToBeat data grid"


### PR DESCRIPTION
Let **Game Activity** plugin charts be resizable with *Theme Modifier* plugin

*d7aa2b0*: feat(DetailsViewGameOverview): use new constant as DynamicResource for chart time and log
*a53b3a2*: feat(Thememodifier): add constant and description for Game Activity plugin chart
*8657364*: feat(Constants): add constant for Game Activity plugin chart